### PR TITLE
Add another page for the Privacy Policy / fix for css styling not showing up

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,11 +4,15 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>The Andagi Company</title>
-  <link rel="stylesheet" href="styles.css" />
+  <link rel="stylesheet" href="format.css" />
 </head>
 <body>
   <header>
     <h1>The Andagi Company - Android Development</h1>
+    <nav>
+        <a href="index.html">Home</a>
+        <a href="privacy.html">Privacy</a>
+    </nav>
     <!-- <h3>
         Hello! 
         I'm David Taylor, a software engineer who has been developing android apps for the past 3 years. 

--- a/privacy.html
+++ b/privacy.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Privacy</title>
+  <link rel="stylesheet" href="format.css">
+</head>
+
+<header>
+  <h1>Privacy Policy</h1>
+    <nav>
+    <a href="index.html">Home</a>
+    <a href="privacy.html">Privacy</a>
+  </nav>
+</header>
+
+<main>
+    <h3>
+        Privacy Policy for Tacoma Music Player
+    </h3>
+    <hr>
+    <br>
+    <p style="text-align: start;">
+        Effective date: 6/3/2025
+        The Andagi Company built the Tacoma Music Player app as a free app. 
+        This music player is provided by The Andagi Company and is intended for use as is.
+    </p>
+    <br>
+    
+    <h3>
+        Information Collection and Use
+    </h3>
+    <hr>
+    <br>
+    <p style="text-align: start;">
+        Tacoma Music Player is intended to be used as an offline mp3 player, as such there is no collection of a user's data. 
+    </p>
+    <br>
+    <h3>
+        Permissions
+    </h3>
+    <hr>
+    <br>
+    <p style="text-align: start;">
+        The Tacoma Music Player is an mp3 player and as such will ask the user for access to "Music and audio", functionality will require this Permission
+        as a requirement to query media files on an android device. These files will be queried and played locally on the device. 
+    </p>
+    <br>
+    <h3>
+        Advertisement
+    </h3>
+    <hr>
+    <br>
+    <p style="text-align: start;">
+        The Tacoma Music Player is a free app, without advertisement. 
+    </p>
+    <br>
+    <h3>
+        Changes to This Privacy Policy
+    </h3>
+    <hr>
+    <br>
+    <p style="text-align: start;">
+        We may update our Privacy Policy from time to time. 
+        Thus, you are advised to review this page periodically for any changes. We will notify you of any changes by posting the new Privacy Policy on this page.
+        If you have any questions or suggestions about our Privacy Policy, do not hesitate to contact at the phone number or email, below. 
+    </p>
+  <script src="script.js"></script>
+</main>
+
+<footer>
+    <h3>Contact Phone Number: (253)-332-0014</h3>
+    <h3>Contact Email: andagicompany@gmail.com</h3>
+    <h3>LinkedIn: https://www.linkedin.com/in/david-taylor-029910166/</h3>
+    <p>&copy; 2025 The Andagi Company</p>
+</footer>
+
+</html>


### PR DESCRIPTION
Google Play submission requires adding a privacy policy to my store listing. This is simple because I'm not really grabbing any of the user's information with my mp3 player app. 

- Also I properly added the css styling to the html files. 

![image](https://github.com/user-attachments/assets/47bcf7b4-ddbc-4d3a-a056-50f1a27cdbab)

![image](https://github.com/user-attachments/assets/6763acf6-aa06-4734-93e5-272c9f11c122)
